### PR TITLE
Add interactive toolbar with magnification and flip controls

### DIFF
--- a/flipper/flipper/.clauiderules
+++ b/flipper/flipper/.clauiderules
@@ -1,0 +1,72 @@
+# Flipper macOS App Development Rules
+
+## SwiftUI Window Coordinate Systems
+
+### Critical Coordinate System Facts
+1. **NSWindow.frame**: Uses Cocoa coordinates with origin at **bottom-left** of screen
+2. **NSWindow.convertToScreen()**: Returns Cocoa coordinates (bottom-left origin)
+3. **ScreenCaptureKit**: Expects coordinates with origin at **top-left** of screen
+4. **Conversion formula**: `topLeftY = displayHeight - bottomLeftY - height`
+
+### Window Content Area Calculation
+When capturing screen content that needs pixel-perfect alignment:
+
+1. **Use window.frame** as the base, not contentLayoutRect alone
+2. **Calculate title bar height**: `titleBarHeight = window.frame.height - window.contentLayoutRect.height`
+3. **Adjust Y origin**: Add title bar height to move from window origin to content area
+4. **Fine-tune offset**: May need additional +/- pixels for borders/spacing (discovered +8 works for this app)
+5. **Reduce height**: Subtract any toolbar/chrome heights from content height
+
+```swift
+let windowFrame = window.frame
+let contentHeight = window.contentLayoutRect.height
+let titleBarHeight = windowFrame.height - contentHeight
+
+var adjustedFrame = windowFrame
+adjustedFrame.origin.y += titleBarHeight + 8  // +8 fine-tune for perfect alignment
+adjustedFrame.size.height = contentHeight - toolbarHeight
+```
+
+## ScreenCaptureKit Best Practices
+
+### Window Exclusion
+Always exclude your own window from capture to prevent recursive imaging:
+```swift
+let ourWindowID = window.windowNumber
+let windowsToExclude = content.windows.filter { $0.windowID == CGWindowID(ourWindowID) }
+let filter = SCContentFilter(display: display, excludingWindows: windowsToExclude)
+```
+
+### Configuration
+- Set `config.width` and `config.height` to match the actual capture region dimensions
+- Use `config.sourceRect` for the screen region to capture
+- The sourceRect uses top-left origin coordinates
+
+## SwiftUI Window Interactivity
+
+### Making Toolbar Controls Interactive
+When window has transparent background:
+1. Set `isMovableByWindowBackground = false` (not true!)
+2. Add drag gesture to content area only for window movement
+3. Leave toolbar without drag gesture so controls receive clicks
+
+### Toolbar Placement
+Bottom toolbar is better than top toolbar because:
+- No offset issues with content area alignment
+- Title bar already at top, toolbar at bottom balances the UI
+- Content area starts at consistent Y position
+
+## Debugging Coordinate Issues
+
+When alignment is off:
+1. Print actual coordinates at each step: `windowFrame`, `contentRect`, `adjustedFrame`
+2. Print display height and calculated Y positions
+3. Check if offset direction matches expectations (up vs down on screen)
+4. Remember: Adding to Y in Cocoa coords moves UP (away from bottom)
+5. Fine-tune with small increments (+/- 2, 4, 8 pixels) until perfect
+
+## Common Pitfalls
+- Don't double-convert coordinates (convertToScreen already gives screen coords)
+- Don't use contentLayoutRect origin directly - it's relative to window, not screen
+- Remember toolbar at bottom reduces content height but doesn't change Y origin
+- Transparent windows need special handling for click-through vs interactivity

--- a/flipper/flipper/ContentView.swift
+++ b/flipper/flipper/ContentView.swift
@@ -4,48 +4,148 @@ import Combine
 struct ContentView: View {
     @StateObject private var captureManager = ScreenCaptureManager()
     @StateObject private var windowObserver = WindowObserver()
+    @State private var magnification: Double = 1.0
+    @State private var flipHorizontal: Bool = true
+    @State private var flipVertical: Bool = false
+    @State private var toolbarHeight: CGFloat = 0
 
     var body: some View {
-        GeometryReader { geometry in
-            ZStack {
-                // Display captured and mirrored screen content
-                if let image = captureManager.capturedImage {
-                    Image(nsImage: image)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .scaleEffect(x: -1, y: 1) // Horizontal mirror
-                        .frame(width: geometry.size.width, height: geometry.size.height)
-                        .clipped()
-                } else {
-                    Color.black.opacity(0.1)
-                }
+        VStack(spacing: 0) {
+            // Main content
+            GeometryReader { geometry in
+                ZStack {
+                    // Display captured and mirrored screen content
+                    if let image = captureManager.capturedImage {
+                        Image(nsImage: image)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .scaleEffect(x: flipHorizontal ? -1 : 1,
+                                       y: flipVertical ? -1 : 1,
+                                       anchor: .center)
+                            .scaleEffect(magnification)
+                            .frame(width: geometry.size.width, height: geometry.size.height)
+                            .clipped()
+                    } else {
+                        Color.black.opacity(0.1)
+                    }
 
-                // Visual border so user can see window bounds
-                RoundedRectangle(cornerRadius: 8)
-                    .strokeBorder(Color.blue.opacity(0.6), lineWidth: 2)
-                    .background(Color.clear)
-            }
-            .frame(minWidth: 200, minHeight: 200)
-            .onAppear {
-                if let window = NSApplication.shared.windows.first {
-                    windowObserver.startObserving(window: window)
+                    // Visual border so user can see window bounds
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(Color.blue.opacity(0.6), lineWidth: 2)
+                        .background(Color.clear)
+                }
+                .frame(minWidth: 200, minHeight: 200)
+                .contentShape(Rectangle())
+                .gesture(DragGesture().onChanged { value in
+                    // Make content area draggable for window movement
+                    if let window = NSApplication.shared.windows.first {
+                        let currentLocation = NSEvent.mouseLocation
+                        let newOrigin = NSPoint(
+                            x: currentLocation.x - value.translation.width,
+                            y: currentLocation.y + value.translation.height
+                        )
+                        window.setFrameOrigin(newOrigin)
+                    }
+                })
+                .onAppear {
+                    if let window = NSApplication.shared.windows.first {
+                        windowObserver.startObserving(window: window)
+                        Task {
+                            // Get the visible content rect (frame minus title bar)
+                            let windowFrame = window.frame
+                            let contentHeight = window.contentLayoutRect.height
+                            let titleBarHeight = windowFrame.height - contentHeight
+
+                            // Adjust frame to exclude title bar and bottom toolbar
+                            var adjustedFrame = windowFrame
+                            adjustedFrame.origin.y += titleBarHeight + 8  // Fine-tune adjustment
+                            adjustedFrame.size.height = contentHeight - toolbarHeight
+
+                            print("DEBUG: windowFrame=\(windowFrame), contentHeight=\(contentHeight), titleBarHeight=\(titleBarHeight), toolbarHeight=\(toolbarHeight), adjustedFrame=\(adjustedFrame)")
+                            await captureManager.startCapture(windowFrame: adjustedFrame, window: window, toolbarHeight: 0)
+                        }
+                    }
+                }
+                .onChange(of: windowObserver.windowFrame) { _, newFrame in
                     Task {
-                        await captureManager.startCapture(windowFrame: window.frame, window: window)
+                        if let window = NSApplication.shared.windows.first {
+                            let windowFrame = window.frame
+                            let contentHeight = window.contentLayoutRect.height
+                            let titleBarHeight = windowFrame.height - contentHeight
+
+                            var adjustedFrame = windowFrame
+                            adjustedFrame.origin.y += titleBarHeight + 8  // Fine-tune adjustment
+                            adjustedFrame.size.height = contentHeight - toolbarHeight
+
+                            captureManager.toolbarHeight = 0
+                            await captureManager.updateCapture(windowFrame: adjustedFrame)
+                        }
+                    }
+                }
+                .onChange(of: geometry.size) { _, newSize in
+                    if let window = NSApplication.shared.windows.first {
+                        Task {
+                            let windowFrame = window.frame
+                            let contentHeight = window.contentLayoutRect.height
+                            let titleBarHeight = windowFrame.height - contentHeight
+
+                            var adjustedFrame = windowFrame
+                            adjustedFrame.origin.y += titleBarHeight + 8  // Fine-tune adjustment
+                            adjustedFrame.size.height = contentHeight - toolbarHeight
+
+                            await captureManager.updateCapture(windowFrame: adjustedFrame)
+                        }
                     }
                 }
             }
-            .onChange(of: windowObserver.windowFrame) { _, newFrame in
-                Task {
-                    await captureManager.updateCapture(windowFrame: newFrame)
+
+            // Toolbar at bottom
+            HStack {
+                Text("Magnification:")
+                    .font(.caption)
+                Slider(value: $magnification, in: 0.0...3.0, step: 0.1)
+                    .frame(width: 150)
+                Text(String(format: "%.1fx", magnification))
+                    .font(.caption)
+                    .frame(width: 40)
+
+                Divider()
+                    .frame(height: 20)
+                    .padding(.horizontal, 8)
+
+                Text("Flip:")
+                    .font(.caption)
+                Button(action: { flipHorizontal.toggle() }) {
+                    Text("Horizontal")
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 4)
+                        .background(flipHorizontal ? Color.blue : Color.gray.opacity(0.3))
+                        .foregroundColor(.white)
+                        .cornerRadius(4)
                 }
-            }
-            .onChange(of: geometry.size) { _, newSize in
-                if let window = NSApplication.shared.windows.first {
-                    Task {
-                        await captureManager.updateCapture(windowFrame: window.frame)
-                    }
+                .buttonStyle(.plain)
+
+                Button(action: { flipVertical.toggle() }) {
+                    Text("Vertical")
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 4)
+                        .background(flipVertical ? Color.blue : Color.gray.opacity(0.3))
+                        .foregroundColor(.white)
+                        .cornerRadius(4)
                 }
+                .buttonStyle(.plain)
+
+                Spacer()
             }
+            .padding(8)
+            .frame(maxWidth: .infinity)
+            .background(Color(NSColor.windowBackgroundColor).opacity(0.8))
+            .background(GeometryReader { geometry in
+                Color.clear.onAppear {
+                    toolbarHeight = geometry.size.height
+                    print("DEBUG: Toolbar height = \(toolbarHeight)")
+                }
+            })
         }
     }
 }

--- a/flipper/flipper/ContentView.swift
+++ b/flipper/flipper/ContentView.swift
@@ -5,7 +5,7 @@ struct ContentView: View {
     @StateObject private var captureManager = ScreenCaptureManager()
     @StateObject private var windowObserver = WindowObserver()
     @State private var magnification: Double = 1.0
-    @State private var flipHorizontal: Bool = true
+    @State private var flipHorizontal: Bool = false
     @State private var flipVertical: Bool = false
     @State private var toolbarHeight: CGFloat = 0
 
@@ -61,7 +61,6 @@ struct ContentView: View {
                             adjustedFrame.origin.y += titleBarHeight + 8  // Fine-tune adjustment
                             adjustedFrame.size.height = contentHeight - toolbarHeight
 
-                            print("DEBUG: windowFrame=\(windowFrame), contentHeight=\(contentHeight), titleBarHeight=\(titleBarHeight), toolbarHeight=\(toolbarHeight), adjustedFrame=\(adjustedFrame)")
                             await captureManager.startCapture(windowFrame: adjustedFrame, window: window, toolbarHeight: 0)
                         }
                     }
@@ -103,7 +102,7 @@ struct ContentView: View {
             HStack {
                 Text("Magnification:")
                     .font(.caption)
-                Slider(value: $magnification, in: 0.0...3.0, step: 0.1)
+                Slider(value: $magnification, in: 1.0...3.0, step: 0.1)
                     .frame(width: 150)
                 Text(String(format: "%.1fx", magnification))
                     .font(.caption)
@@ -143,7 +142,6 @@ struct ContentView: View {
             .background(GeometryReader { geometry in
                 Color.clear.onAppear {
                     toolbarHeight = geometry.size.height
-                    print("DEBUG: Toolbar height = \(toolbarHeight)")
                 }
             })
         }

--- a/flipper/flipper/ScreenCaptureView.swift
+++ b/flipper/flipper/ScreenCaptureView.swift
@@ -7,8 +7,10 @@ class ScreenCaptureManager: ObservableObject {
     private var stream: SCStream?
     private var streamOutput: StreamOutput?
     private var ourWindow: NSWindow?
+    var toolbarHeight: CGFloat = 0
 
-    func startCapture(windowFrame: CGRect, window: NSWindow) async {
+    func startCapture(windowFrame: CGRect, window: NSWindow, toolbarHeight: CGFloat = 0) async {
+        self.toolbarHeight = toolbarHeight
         self.ourWindow = window
 
         do {
@@ -72,10 +74,18 @@ class ScreenCaptureManager: ObservableObject {
     }
 
     private func convertToScreenCaptureCoordinates(windowFrame: CGRect, displayHeight: CGFloat) -> CGRect {
-        // NSWindow.frame has origin at bottom-left, but ScreenCaptureKit expects top-left
-        // Convert by flipping the Y coordinate
+        // windowFrame comes from convertToScreen which uses Cocoa coordinates (origin bottom-left)
+        // ScreenCaptureKit expects coordinates with origin at top-left
+        // So we need to flip: top-left Y = displayHeight - bottom-left Y - height
         let flippedY = displayHeight - windowFrame.origin.y - windowFrame.height
-        return CGRect(x: windowFrame.origin.x, y: flippedY, width: windowFrame.width, height: windowFrame.height)
+        let result = CGRect(
+            x: windowFrame.origin.x,
+            y: flippedY,
+            width: windowFrame.width,
+            height: windowFrame.height
+        )
+        print("DEBUG: displayHeight=\(displayHeight), windowFrame=\(windowFrame), flippedY=\(flippedY), captureRect=\(result)")
+        return result
     }
 
     func stopCapture() async {

--- a/flipper/flipper/ScreenCaptureView.swift
+++ b/flipper/flipper/ScreenCaptureView.swift
@@ -78,14 +78,12 @@ class ScreenCaptureManager: ObservableObject {
         // ScreenCaptureKit expects coordinates with origin at top-left
         // So we need to flip: top-left Y = displayHeight - bottom-left Y - height
         let flippedY = displayHeight - windowFrame.origin.y - windowFrame.height
-        let result = CGRect(
+        return CGRect(
             x: windowFrame.origin.x,
             y: flippedY,
             width: windowFrame.width,
             height: windowFrame.height
         )
-        print("DEBUG: displayHeight=\(displayHeight), windowFrame=\(windowFrame), flippedY=\(flippedY), captureRect=\(result)")
-        return result
     }
 
     func stopCapture() async {

--- a/flipper/flipper/flipperApp.swift
+++ b/flipper/flipper/flipperApp.swift
@@ -33,7 +33,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
         window.styleMask.insert(.fullSizeContentView)
-        window.isMovableByWindowBackground = true
+        window.isMovableByWindowBackground = false  // Changed to false to allow toolbar interaction
         window.level = .floating
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
     }

--- a/flipper/flipper/flipperApp.swift
+++ b/flipper/flipper/flipperApp.swift
@@ -27,11 +27,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func configureTransparentWindow(_ window: NSWindow) {
+        window.title = "Flipper"
         window.isOpaque = false
         window.backgroundColor = .clear
         window.hasShadow = false
         window.titlebarAppearsTransparent = true
-        window.titleVisibility = .hidden
+        window.titleVisibility = .visible
         window.styleMask.insert(.fullSizeContentView)
         window.isMovableByWindowBackground = false  // Changed to false to allow toolbar interaction
         window.level = .floating

--- a/flipper/flipper/flipperApp.swift
+++ b/flipper/flipper/flipperApp.swift
@@ -15,7 +15,6 @@ struct flipperApp: App {
         WindowGroup {
             ContentView()
         }
-        .windowStyle(.hiddenTitleBar)
     }
 }
 
@@ -31,9 +30,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.isOpaque = false
         window.backgroundColor = .clear
         window.hasShadow = false
-        window.titlebarAppearsTransparent = true
+        window.titlebarAppearsTransparent = false  // Make title bar opaque so title is visible
         window.titleVisibility = .visible
-        window.styleMask.insert(.fullSizeContentView)
         window.isMovableByWindowBackground = false  // Changed to false to allow toolbar interaction
         window.level = .floating
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]


### PR DESCRIPTION
## Summary
Adds a fully interactive bottom toolbar with magnification slider and horizontal/vertical flip toggle buttons. Includes precise screen capture alignment for pixel-perfect display of mirrored background content.

## Features Added
- **Bottom toolbar** with semi-transparent background
- **Magnification slider** (1.0x to 3.0x) with live value display
- **Horizontal and vertical flip toggles** with visual state (blue when active)
- **Interactive controls** that properly receive mouse events
- **Visible window title** "Flipper" in title bar

## Technical Improvements
- Fixed window interactivity by disabling `isMovableByWindowBackground`
- Added drag gesture to content area for window movement
- Implemented precise coordinate conversion for screen capture alignment
- Calculate exact content area by adjusting for title bar and toolbar heights
- Use `window.contentLayoutRect` with +8 pixel fine-tune offset for perfect alignment
- Exclude our own window from screen capture to prevent recursive imaging
- Added development rules documentation for coordinate systems and ScreenCaptureKit

## Testing
- [x] Screen content aligns perfectly with background (no vertical offset)
- [x] Toolbar controls are fully interactive
- [x] Magnification slider works smoothly (1.0x - 3.0x range)
- [x] Flip buttons toggle independently and show correct visual state
- [x] Window is draggable via content area
- [x] Window title is visible

## Commits
- Add interactive toolbar with magnification and flip controls
- Add development rules for window coordinate systems and ScreenCaptureKit
- Set default state and remove debug logging
- Add visible 'Flipper' window title

🤖 Generated with [Claude Code](https://claude.com/claude-code)